### PR TITLE
security: enforce HTTPS for Javadoc external links

### DIFF
--- a/libraries/tools/kotlin-stdlib-docs/build.gradle.kts
+++ b/libraries/tools/kotlin-stdlib-docs/build.gradle.kts
@@ -366,8 +366,8 @@ fun createKotlinTestVersionedDocTask(version: String, isLatest: Boolean) =
                 sourceRoots.from("$kotlin_root/libraries/kotlin.test/junit/src/main/kotlin")
 
                 externalDocumentationLink {
-                    url.set(URL("http://junit.org/junit4/javadoc/latest/"))
-                    packageListUrl.set(URL("http://junit.org/junit4/javadoc/latest/package-list"))
+                    url.set(URL("https://junit.org/junit4/javadoc/latest/"))
+                    packageListUrl.set(URL("https://junit.org/junit4/javadoc/latest/package-list"))
                 }
             }
 


### PR DESCRIPTION
**Fix:** Upgrade `junit.org` Javadoc URLs to HTTPS in `build.gradle.kts`.

**Security Rationale:**
Currently, the build script fetches Javadoc resources over plain HTTP (`http://junit.org`). 
Although the server redirects to HTTPS, the initial cleartext request is vulnerable to **Man-in-the-Middle (MitM) stripping attacks**. An attacker on the network could intercept this request and inject malicious artifacts (like a spoofed `package-list`) before the secure redirect occurs.

Hardcoding HTTPS guarantees a secure connection from the start and ensures the integrity of the generated documentation.